### PR TITLE
Track visitor counts via Amplify data

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,15 +1,10 @@
 import { type ClientSchema, a, defineData } from "@aws-amplify/backend";
 
-/*== STEP 1 ===============================================================
-The section below creates a Todo database table with a "content" field. Try
-adding a new "isDone" field as a boolean. The authorization rule below
-specifies that any user authenticated via an API key can "create", "read",
-"update", and "delete" any "Todo" records.
-=========================================================================*/
 const schema = a.schema({
-  Todo: a
+  VisitorLog: a
     .model({
-      content: a.string(),
+      ipAddress: a.string().required(),
+      visitedAt: a.datetime().required(),
     })
     .authorization((allow) => [allow.publicApiKey()]),
 });
@@ -25,32 +20,3 @@ export const data = defineData({
     },
   },
 });
-
-/*== STEP 2 ===============================================================
-Go to your frontend source code. From your client-side code, generate a
-Data client to make CRUDL requests to your table. (THIS SNIPPET WILL ONLY
-WORK IN THE FRONTEND CODE FILE.)
-
-Using JavaScript or Next.js React Server Components, Middleware, Server 
-Actions or Pages Router? Review how to generate Data clients for those use
-cases: https://docs.amplify.aws/gen2/build-a-backend/data/connect-to-API/
-=========================================================================*/
-
-/*
-"use client"
-import { generateClient } from "aws-amplify/data";
-import type { Schema } from "@/amplify/data/resource";
-
-const client = generateClient<Schema>() // use this Data client for CRUDL requests
-*/
-
-/*== STEP 3 ===============================================================
-Fetch records from the database and use them in your frontend component.
-(THIS SNIPPET WILL ONLY WORK IN THE FRONTEND CODE FILE.)
-=========================================================================*/
-
-/* For example, in a React component, you can use this snippet in your
-  function's RETURN statement */
-// const { data: todos } = await client.models.Todo.list()
-
-// return <ul>{todos.map(todo => <li key={todo.id}>{todo.content}</li>)}</ul>

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,9 +15,8 @@ body {
 body {
   min-height: 100vh;
   min-width: 100vw;
-  background-color: #0b1120;
-  color: #0f172a;
-  overflow: hidden;
+  background-color: #f8fafc;
+  color: #111827;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,8 +5,9 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Interactive Gradient Background",
-  description: "Immersive animated gradient landing experience.",
+  title: "Anzahl Besucher",
+  description:
+    "Übersicht über die Anzahl der aufgezeichneten Seitenaufrufe.",
 };
 
 export default function RootLayout({
@@ -15,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="de">
       <body className={inter.className}>{children}</body>
     </html>
   );

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,68 +1,23 @@
 .page {
-  position: relative;
+  min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
-  width: 100%;
-  overflow: hidden;
   padding: 2rem;
 }
 
-.canvas {
-  position: fixed;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  --gradient-color-1: #a960ee;
-  --gradient-color-2: #ff333d;
-  --gradient-color-3: #90e0ff;
-  --gradient-color-4: #ffcb57;
-  z-index: 0;
-}
-
-.title {
-  position: relative;
-  z-index: 1;
-  max-width: 480px;
-  background: rgb(255 255 255 / 26%);
-  border-radius: 10px;
-  border: 1px solid rgb(255 255 255 / 15%);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  padding: 2.5rem 3rem;
-  text-align: center;
-  color: #ffffff;
-  line-height: 1.5;
-  box-shadow: 0 20px 60px rgb(17 24 39 / 35%);
-}
-
-.title h1 {
-  font-size: clamp(2rem, 3vw + 1rem, 3rem);
+.counter {
+  font-size: clamp(2.5rem, 3vw + 1.5rem, 4rem);
   font-weight: 600;
-  margin-bottom: 1rem;
+  color: #1f2937;
+  text-align: center;
 }
 
-.title p {
-  font-size: 1rem;
-  margin: 0;
-  opacity: 0.9;
+.label {
+  font-weight: 500;
 }
 
-@media (max-width: 600px) {
-  .page {
-    padding: 1.5rem;
-  }
-
-  .title {
-    padding: 2rem 1.75rem;
-  }
-
-  .title h1 {
-    font-size: clamp(1.75rem, 6vw, 2.5rem);
-  }
-
-  .title p {
-    font-size: 0.95rem;
-  }
+.value {
+  font-weight: 700;
+  color: #111827;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,22 +1,64 @@
-import Script from "next/script";
+import { generateClient } from "aws-amplify/data";
+import { headers } from "next/headers";
 import styles from "./page.module.css";
+import type { Schema } from "@/amplify/data/resource";
 
-export default function Home() {
+export const dynamic = "force-dynamic";
+
+const client = generateClient<Schema>();
+
+type HeaderList = ReturnType<typeof headers>;
+
+function extractClientIp(headerList: HeaderList): string {
+  const headerCandidates = [
+    "x-forwarded-for",
+    "x-real-ip",
+    "cf-connecting-ip",
+    "true-client-ip",
+    "fastly-client-ip",
+  ];
+
+  for (const name of headerCandidates) {
+    const value = headerList.get(name);
+    if (value) {
+      const candidate = value.split(",")[0]?.trim();
+      if (candidate) {
+        return candidate;
+      }
+    }
+  }
+
+  const remoteAddress = headerList.get("remote-addr");
+  if (remoteAddress) {
+    return remoteAddress;
+  }
+
+  return "unknown";
+}
+
+export default async function Home() {
+  const headerList = headers();
+  const ipAddress = extractClientIp(headerList);
+  let visitCount = 0;
+
+  try {
+    await client.models.VisitorLog.create({
+      ipAddress,
+      visitedAt: new Date().toISOString(),
+    });
+
+    const { data: visits } = await client.models.VisitorLog.list();
+    visitCount = visits?.length ?? 0;
+  } catch (error) {
+    console.error("Failed to record visit", error);
+  }
+
   return (
     <main className={styles.page}>
-      <canvas
-        id="gradient-canvas"
-        className={styles.canvas}
-        aria-hidden="true"
-      />
-      <div className={styles.title}>
-        <h1>Interactive Gradient Background</h1>
-        <p>
-          A shimmering, ever-changing gradient rendered in WebGL. Sit back and
-          enjoy the ambient motion.
-        </p>
-      </div>
-      <Script src="/gradient.js" strategy="afterInteractive" />
+      <p className={styles.counter}>
+        <span className={styles.label}>Anzahl Besucher:</span>{" "}
+        <span className={styles.value}>{visitCount}</span>
+      </p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- replace the sample Todo data model with a VisitorLog table that stores the IP address and timestamp for each visit
- log each request on the home page using the Amplify Data client and render the total visitor count
- simplify the layout by removing the gradient canvas, updating metadata, and styling the page for the visitor counter only

## Testing
- `npm run lint` *(fails: ESLint must be installed in this template)*
- `npm run build` *(fails: Next.js cannot download the Inter font without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb0f4c8408332a19134e3eeeb3f41